### PR TITLE
Fix gh-pages push auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy": "npm run build && gh-pages -d dist"
+    "deploy": "npm run build && gh-pages -d dist -r https://$GH_TOKEN@github.com/$GITHUB_REPOSITORY.git"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- fix GitHub Pages deploy script to use authentication

## Testing
- `npm run build`
- *(deployment script run with dummy token aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6851a720c240832fbe65f161c29b60c1