### PR TITLE
Add Leaflet map with YAML POIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project provides a simple TypeScript setup powered by [Vite](https://vitejs.dev/) for building a static website that can be published to GitHub Pages.
 
+A small Leaflet demo map is included. Points of interest are loaded from `src/pois.yaml` and displayed with marker clustering.
+
 ## Development
 
 ```bash

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>TF CV Site</title>
 </head>
 <body>
-  <div id="app"></div>
+  <div id="map" style="height: 100vh;"></div>
   <script type="module" src="/src/index.ts"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,13 @@
       "name": "tf-cv-site",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "@types/leaflet": "^1.9.18",
+        "@types/leaflet.markercluster": "^1.5.5",
+        "js-yaml": "^4.1.0",
+        "leaflet": "^1.9.4",
+        "leaflet.markercluster": "^1.5.3"
+      },
       "devDependencies": {
         "@types/node": "^24.0.3",
         "gh-pages": "^6.3.0",
@@ -765,6 +772,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.18",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.18.tgz",
+      "integrity": "sha512-ht2vsoPjezor5Pmzi5hdsA7F++v5UGq9OlUduWHmMZiuQGIpJ2WS5+Gg9HaAA79gNh1AIPtCqhzejcIZ3lPzXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/leaflet.markercluster": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/leaflet.markercluster/-/leaflet.markercluster-1.5.5.tgz",
+      "integrity": "sha512-TkWOhSHDM1ANxmLi+uK0PjsVcjIKBr8CLV2WoF16dIdeFmC0Cj5P5axkI3C1Xsi4+ht6EU8+BfEbbqEF9icPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/leaflet": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.0.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
@@ -774,6 +805,12 @@
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -1130,6 +1167,18 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1141,6 +1190,21 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -18,5 +18,12 @@
     "gh-pages": "^6.3.0",
     "typescript": "^5.8.3",
     "vite": "^6.3.5"
+  },
+  "dependencies": {
+    "@types/leaflet": "^1.9.18",
+    "@types/leaflet.markercluster": "^1.5.5",
+    "js-yaml": "^4.1.0",
+    "leaflet": "^1.9.4",
+    "leaflet.markercluster": "^1.5.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,34 @@
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import 'leaflet.markercluster';
+import 'leaflet.markercluster/dist/MarkerCluster.css';
+import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
+import { loadPois, Poi } from './loadPois';
+
 export function main() {
-  const root = document.getElementById('app');
-  if (root) {
-    root.textContent = 'Hello, GitHub Pages!';
-  }
+  const map = L.map('map', {
+    center: [0, 0],
+    zoom: 2,
+  });
+
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '© OpenStreetMap contributors',
+  }).addTo(map);
+
+  const clusterGroup = L.markerClusterGroup();
+  const pois: Poi[] = loadPois();
+
+  pois.forEach((poi) => {
+    const marker = L.marker([poi.lat, poi.lng]);
+    marker.bindPopup(
+      `<h3>${poi.name}</h3>` +
+        (poi.description ? `<p>${poi.description}</p>` : '') +
+        (poi.image ? `<img src="${poi.image}" alt="${poi.name}">` : '')
+    );
+    clusterGroup.addLayer(marker);
+  });
+
+  map.addLayer(clusterGroup);
 }
 
 main();

--- a/src/loadPois.ts
+++ b/src/loadPois.ts
@@ -1,0 +1,14 @@
+import * as yaml from 'js-yaml';
+import poiData from './pois.yaml?raw';
+
+export interface Poi {
+  name: string;
+  lat: number;
+  lng: number;
+  description?: string;
+  image?: string;
+}
+
+export function loadPois(): Poi[] {
+  return yaml.load(poiData) as Poi[];
+}

--- a/src/pois.yaml
+++ b/src/pois.yaml
@@ -1,0 +1,12 @@
+- name: Eiffel Tower
+  lat: 48.8584
+  lng: 2.2945
+  description: "Iconic Parisian landmark"
+- name: Statue of Liberty
+  lat: 40.6892
+  lng: -74.0445
+  description: "Famous statue in New York City"
+- name: Great Wall of China
+  lat: 40.4319
+  lng: 116.5704
+  description: "Historic fortification"

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -1,0 +1,1 @@
+declare module '*.yaml?raw';


### PR DESCRIPTION
## Summary
- add Leaflet and markercluster dependencies
- build map container in `index.html`
- parse POIs from YAML and display them with clustering
- describe the map feature in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851a407feec832fadd0f895a9c558ed