### PR TITLE
build: set base path for gh-pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'vite';
 
+// Configure the base path so asset URLs work correctly when
+// deployed to GitHub Pages under the "tf-cv-site" repository.
+
 export default defineConfig({
   root: '.',
+  base: '/tf-cv-site/',
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- set `base` in Vite config so assets resolve correctly on GitHub Pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851aab1cdbc832f9adf6690eaf18289