### PR TITLE
build: set base path for gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ npm run deploy
 ```
 
 This builds the site and publishes the contents of `dist` to the `gh-pages` branch using the `gh-pages` package.
+Make sure the `base` option in `vite.config.ts` matches the repository
+name (e.g. `/tf-cv-site/`) so that asset URLs are resolved correctly on
+GitHub Pages.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   root: '.',
+  // Set the base path so that assets resolve correctly when the site
+  // is served from the "tf-cv-site" subpath on GitHub Pages.
+  base: '/tf-cv-site/',
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- set Vite `base` option so assets load correctly on GitHub Pages
- note base path requirement in the README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851acfad984832faa99f435fdb23d20