### PR TITLE
map: fix leaflet icon paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,16 @@ import 'leaflet.markercluster';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 import { loadPois, Poi } from './loadPois';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
 
 export function main() {
+  L.Icon.Default.mergeOptions({
+    iconUrl: markerIcon,
+    iconRetinaUrl: markerIcon2x,
+    shadowUrl: markerShadow,
+  });
   const map = L.map('map', {
     center: [0, 0],
     zoom: 2,

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -1,1 +1,2 @@
 declare module '*.yaml?raw';
+declare module '*.png';


### PR DESCRIPTION
## Summary
- ensure Leaflet markers resolve correctly when built for GitHub Pages
- add PNG module declaration for TypeScript

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851b2764410832f85ec074f5184c14f