### PR TITLE
map: add POI ID card component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@types/leaflet.markercluster": "^1.5.5",
         "js-yaml": "^4.1.0",
         "leaflet": "^1.9.4",
-        "leaflet.markercluster": "^1.5.3"
+        "leaflet.markercluster": "^1.5.3",
+        "marked": "^12.0.2"
       },
       "devDependencies": {
         "@types/node": "^24.0.3",
@@ -1234,6 +1235,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/leaflet.markercluster": "^1.5.5",
     "js-yaml": "^4.1.0",
     "leaflet": "^1.9.4",
-    "leaflet.markercluster": "^1.5.3"
+    "leaflet.markercluster": "^1.5.3",
+    "marked": "^12.0.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,15 @@ import 'leaflet.markercluster';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 import { loadPois, Poi } from './loadPois';
+import { initPoiCard, showPoiCard } from './poiCard';
 
 export function main() {
   const map = L.map('map', {
     center: [0, 0],
     zoom: 2,
   });
+
+  initPoiCard();
 
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '© OpenStreetMap contributors',
@@ -20,11 +23,7 @@ export function main() {
 
   pois.forEach((poi) => {
     const marker = L.marker([poi.lat, poi.lng]);
-    marker.bindPopup(
-      `<h3>${poi.name}</h3>` +
-        (poi.description ? `<p>${poi.description}</p>` : '') +
-        (poi.image ? `<img src="${poi.image}" alt="${poi.name}">` : '')
-    );
+    marker.on('click', () => showPoiCard(poi));
     clusterGroup.addLayer(marker);
   });
 

--- a/src/loadPois.ts
+++ b/src/loadPois.ts
@@ -7,6 +7,7 @@ export interface Poi {
   lng: number;
   description?: string;
   image?: string;
+  details?: string;
 }
 
 export function loadPois(): Poi[] {

--- a/src/poiCard.ts
+++ b/src/poiCard.ts
@@ -1,0 +1,67 @@
+import { marked } from 'marked';
+import type { Poi } from './loadPois';
+
+let overlay: HTMLDivElement | null = null;
+let card: HTMLDivElement | null = null;
+
+export function initPoiCard() {
+  overlay = document.createElement('div');
+  overlay.id = 'poi-card-overlay';
+  Object.assign(overlay.style, {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    width: '100%',
+    height: '100%',
+    background: 'rgba(0,0,0,0.5)',
+    display: 'none',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: '1000',
+  } as CSSStyleDeclaration);
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) {
+      hidePoiCard();
+    }
+  });
+
+  card = document.createElement('div');
+  card.id = 'poi-card';
+  Object.assign(card.style, {
+    background: 'white',
+    maxWidth: '600px',
+    maxHeight: '80vh',
+    overflowY: 'auto',
+    padding: '1rem',
+  } as CSSStyleDeclaration);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.style.float = 'right';
+  closeBtn.addEventListener('click', hidePoiCard);
+  card.appendChild(closeBtn);
+
+  overlay.appendChild(card);
+  document.body.appendChild(overlay);
+}
+
+export function showPoiCard(poi: Poi) {
+  if (!overlay || !card) {
+    initPoiCard();
+  }
+  if (!overlay || !card) return;
+  const html = `
+    <h2>${poi.name}</h2>
+    ${poi.details ? marked.parse(poi.details) : ''}
+  `;
+  card.innerHTML = '<button style="float:right">Close</button>' + html;
+  const close = card.querySelector('button');
+  close?.addEventListener('click', hidePoiCard);
+  overlay.style.display = 'flex';
+}
+
+export function hidePoiCard() {
+  if (overlay) {
+    overlay.style.display = 'none';
+  }
+}

--- a/src/pois.yaml
+++ b/src/pois.yaml
@@ -2,11 +2,22 @@
   lat: 48.8584
   lng: 2.2945
   description: "Iconic Parisian landmark"
+  details: |
+    ![Eiffel Tower](https://upload.wikimedia.org/wikipedia/commons/a/a8/Tour_Eiffel_Wikimedia_Commons.jpg)
+    The Eiffel Tower is an iron lattice tower in Paris, France.
+
 - name: Statue of Liberty
   lat: 40.6892
   lng: -74.0445
   description: "Famous statue in New York City"
+  details: |
+    ![Statue of Liberty](https://upload.wikimedia.org/wikipedia/commons/a/a1/Statue_of_Liberty_7.jpg)
+    The Statue of Liberty was a gift from France to the United States.
+
 - name: Great Wall of China
   lat: 40.4319
   lng: 116.5704
   description: "Historic fortification"
+  details: |
+    ![Great Wall](https://upload.wikimedia.org/wikipedia/commons/1/10/20090529_Great_Wall_8185.jpg)
+    The Great Wall stretches thousands of miles across China.


### PR DESCRIPTION
## Summary
- add `marked` for Markdown parsing
- implement `poiCard` component
- expand POI YAML to include Markdown details
- show ID card on marker click

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851b26bef24832f83e50ce32f77e493