### PR TITLE
style: move poi card styles to css

### DIFF
--- a/src/poiCard.ts
+++ b/src/poiCard.ts
@@ -7,18 +7,6 @@ let card: HTMLDivElement | null = null;
 export function initPoiCard() {
   overlay = document.createElement('div');
   overlay.id = 'poi-card-overlay';
-  Object.assign(overlay.style, {
-    position: 'fixed',
-    top: '0',
-    left: '0',
-    width: '100%',
-    height: '100%',
-    background: 'rgba(0,0,0,0.5)',
-    display: 'none',
-    alignItems: 'center',
-    justifyContent: 'center',
-    zIndex: '1000',
-  } as CSSStyleDeclaration);
   overlay.addEventListener('click', (e) => {
     if (e.target === overlay) {
       hidePoiCard();
@@ -27,22 +15,6 @@ export function initPoiCard() {
 
   card = document.createElement('div');
   card.id = 'poi-card';
-  Object.assign(card.style, {
-    background: 'white',
-    maxWidth: '600px',
-    maxHeight: '80vh',
-    overflowY: 'auto',
-    padding: '1rem',
-    boxSizing: 'border-box',
-    wordBreak: 'break-word',
-    borderRadius: '8px',
-  } as CSSStyleDeclaration);
-
-  const closeBtn = document.createElement('button');
-  closeBtn.textContent = 'Close';
-  closeBtn.style.float = 'right';
-  closeBtn.addEventListener('click', hidePoiCard);
-  card.appendChild(closeBtn);
 
   overlay.appendChild(card);
   document.body.appendChild(overlay);
@@ -65,17 +37,13 @@ export function showPoiCard(poi: Poi) {
     ${content}
   `;
 
-  card.innerHTML = '<button style="float:right">Close</button>' + html;
-  const close = card.querySelector('button');
-  close?.addEventListener('click', hidePoiCard);
-
-  card.querySelectorAll('img').forEach((img) => {
-    const el = img as HTMLImageElement;
-    el.style.maxWidth = '100%';
-    el.style.height = 'auto';
-    el.style.display = 'block';
-    el.style.margin = '0 auto';
-  });
+  card.innerHTML = '';
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Close';
+  closeBtn.className = 'close-btn';
+  closeBtn.addEventListener('click', hidePoiCard);
+  card.appendChild(closeBtn);
+  card.insertAdjacentHTML('beforeend', html);
 
   overlay.style.display = 'flex';
 }

--- a/src/style.css
+++ b/src/style.css
@@ -29,3 +29,40 @@ body {
 .leaflet-tile {
   filter: var(--map-tint);
 }
+
+/* Styles for the point of interest card overlay */
+#poi-card-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+/* Styles for the card content */
+#poi-card {
+  background: white;
+  max-width: 600px;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 1rem;
+  box-sizing: border-box;
+  word-break: break-word;
+  border-radius: 8px;
+}
+
+#poi-card img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
+#poi-card .close-btn {
+  float: right;
+}


### PR DESCRIPTION
## Summary
- move POI card styles out of TypeScript and into CSS

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685694ecb264832fbea821a1fbea3e24