### PR TITLE
ui: split sections into individual pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This project provides a simple TypeScript setup powered by [Vite](https://vitejs
 
 A small Leaflet demo map is included. Points of interest are loaded from `src/pois.yaml` and displayed with marker clustering.
 
+The site is organised as three pages accessible from the navigation menu:
+`cv.html`, `map.html` and `portfolio.html`.
+
 ## Development
 
 ```bash

--- a/cv.html
+++ b/cv.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>TF CV Site</title>
+  <title>CV - TF CV Site</title>
   <link rel="stylesheet" href="/src/style.css" />
 </head>
 <body>
@@ -14,9 +14,9 @@
       <li><a href="portfolio.html">Portfolio</a></li>
     </ul>
   </nav>
-  <section>
-    <h1>Welcome</h1>
-    <p>Select a section from the menu.</p>
+  <section id="cv">
+    <h1>CV</h1>
+    <p>Add your curriculum vitae details here.</p>
   </section>
 </body>
 </html>

--- a/map.html
+++ b/map.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>TF CV Site</title>
+  <title>Map - TF CV Site</title>
   <link rel="stylesheet" href="/src/style.css" />
 </head>
 <body>
@@ -14,9 +14,7 @@
       <li><a href="portfolio.html">Portfolio</a></li>
     </ul>
   </nav>
-  <section>
-    <h1>Welcome</h1>
-    <p>Select a section from the menu.</p>
-  </section>
+  <div id="map"></div>
+  <script type="module" src="/src/index.ts"></script>
 </body>
 </html>

--- a/portfolio.html
+++ b/portfolio.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>TF CV Site</title>
+  <title>Portfolio - TF CV Site</title>
   <link rel="stylesheet" href="/src/style.css" />
 </head>
 <body>
@@ -14,9 +14,9 @@
       <li><a href="portfolio.html">Portfolio</a></li>
     </ul>
   </nav>
-  <section>
-    <h1>Welcome</h1>
-    <p>Select a section from the menu.</p>
+  <section id="portfolio">
+    <h1>Portfolio</h1>
+    <p>Showcase your projects here.</p>
   </section>
 </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        main: 'index.html',
+        cv: 'cv.html',
+        map: 'map.html',
+        portfolio: 'portfolio.html',
+      },
+    },
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary
- split content into `cv.html`, `map.html` and `portfolio.html`
- update main landing page navigation
- include additional pages in `vite` build
- document new page layout

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856990a3db0832f8ca7196298ac58ae