### PR TITLE
map: load assets asynchronously

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,24 @@
-import L from 'leaflet';
-import 'leaflet/dist/leaflet.css';
-import 'leaflet.markercluster';
-import 'leaflet.markercluster/dist/MarkerCluster.css';
-import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 import { loadPois, Poi } from './loadPois';
 import { initPoiCard, showPoiCard } from './poiCard';
-import markerIcon from './assets/marker-icon.png';
-import markerIcon2x from './assets/marker-icon-2x.png';
-import markerShadow from './assets/marker-shadow.png';
 import './style.css';
 
-export function main() {
-  var Icon = L.icon({
+export async function main() {
+  // Dynamically import map libraries and assets so initial page load is light
+  const [{ default: L }, _mc] = await Promise.all([
+    import('leaflet'),
+    import('leaflet.markercluster'),
+  ]);
+  await Promise.all([
+    import('leaflet/dist/leaflet.css'),
+    import('leaflet.markercluster/dist/MarkerCluster.css'),
+    import('leaflet.markercluster/dist/MarkerCluster.Default.css'),
+  ]);
+
+  const markerIcon = (await import('./assets/marker-icon.png')).default;
+  const markerIcon2x = (await import('./assets/marker-icon-2x.png')).default;
+  const markerShadow = (await import('./assets/marker-shadow.png')).default;
+
+  const Icon = L.icon({
     ...L.Icon.Default.prototype.options,
     iconUrl: markerIcon,
     iconRetinaUrl: markerIcon2x,
@@ -29,7 +36,7 @@ export function main() {
   }).addTo(map);
 
   const clusterGroup = L.markerClusterGroup();
-  const pois: Poi[] = loadPois();
+  const pois: Poi[] = await loadPois();
 
   pois.forEach((poi) => {
     const marker = L.marker([poi.lat, poi.lng], {icon: Icon});
@@ -40,4 +47,4 @@ export function main() {
   map.addLayer(clusterGroup);
 }
 
-main();
+main().catch((err) => console.error(err));

--- a/src/loadPois.ts
+++ b/src/loadPois.ts
@@ -1,5 +1,5 @@
-import * as yaml from 'js-yaml';
-import poiData from './pois.yaml?raw';
+// Load POI data on demand so assets aren't bundled
+// with the initial JavaScript payload.
 
 export interface Poi {
   name: string;
@@ -10,6 +10,14 @@ export interface Poi {
   details?: string;
 }
 
-export function loadPois(): Poi[] {
-  return yaml.load(poiData) as Poi[];
+/**
+ * Fetch and parse the POI YAML file asynchronously.
+ */
+export async function loadPois(): Promise<Poi[]> {
+  // Use dynamic import so the file can be inlined by the bundler and also
+  // fetched at runtime when needed.
+  const data = (await import('./pois.yaml?raw')).default as string;
+  let text = data;
+  const yaml = await import('js-yaml');
+  return yaml.load(text) as Poi[];
 }

--- a/tests/loadPois.test.ts
+++ b/tests/loadPois.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { loadPois } from '../src/loadPois';
 
 describe('loadPois', () => {
-  it('parses YAML data', () => {
-    const pois = loadPois();
+  it('parses YAML data', async () => {
+    const pois = await loadPois();
     expect(pois.length).toBeGreaterThan(0);
     expect(pois[0].name).toBe('Eiffel Tower');
   });


### PR DESCRIPTION
## Summary
- load POI data asynchronously using dynamic import
- dynamically import Leaflet libs and marker images on map init
- update tests for async loading

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856abeb5b30832f8b5eb6fb6e39a16a